### PR TITLE
New Super Mario Wii: Correct devices to Wiimote

### DIFF
--- a/New Super Mario Wii/output_Devices.json
+++ b/New Super Mario Wii/output_Devices.json
@@ -5,7 +5,7 @@
     "tex1_370x225_fa54a6d10379441d_5.png": {
       "image": "tex1_370x225_fa54a6d10379441d_5.png",
       "emulated_controls": {
-        "GCPad1": {
+        "Wiimote1": {
           "Device": [
             [
               0.0,
@@ -43,7 +43,7 @@
     "tex1_384x220_10fe968a8801039c_5.png": {
       "image": "tex1_384x220_10fe968a8801039c_5.png",
       "emulated_controls": {
-        "GCPad1": {
+        "Wiimote1": {
           "Device": [
             [
               0.0,


### PR DESCRIPTION
Correct output_Devices.json from GCPad1 to Wiimote1 for New Super Mario Bros Wii