### PR TITLE
Add Linux DualShock4 device image support

### DIFF
--- a/F-ZERO GX/output_Devices.json
+++ b/F-ZERO GX/output_Devices.json
@@ -37,6 +37,12 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "..\\#DefaultDevices\\DualShock4\\Device\\3D-front.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front.png"
 			    }
 	    }
     }

--- a/Kirby Air Ride/output_Devices.json
+++ b/Kirby Air Ride/output_Devices.json
@@ -37,6 +37,12 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "..\\#DefaultDevices\\DualShock4\\Device\\Icon-Simple.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon-Simple.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon-Simple.png"
 			    }
 	    }
     },
@@ -75,6 +81,12 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "..\\#DefaultDevices\\DualShock4\\Device\\Icon-Simple.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon-Simple.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon-Simple.png"
 			    }
 	    }
     }

--- a/Mario Kart Double Dash/output_Devices.json
+++ b/Mario Kart Double Dash/output_Devices.json
@@ -21,7 +21,7 @@
 				"DSUClient/1/BetterJoy": "../#DefaultDevices/Switch_Joy-Con/Device/IconN.png"
 			    },
 		      "DSUClient/0/BetterJoy": {
-				"DSUClient/0/BetterJoy": "../#DefaultDevices/Switch_Pro Controller/Device\\IconN.png"
+				"DSUClient/0/BetterJoy": "../#DefaultDevices/Switch_Pro Controller/Device/IconN.png"
 			    },
 		      "DInput/0/Wireless Gamepad": {
 				"DInput/0/Wireless Gamepad": "..\\#DefaultDevices\\Switch_Pro Controller\\Device\\IconN.png"
@@ -37,6 +37,12 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "..\\#DefaultDevices\\DualShock4\\Device\\IconN.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/IconN.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/IconN.png"
 			    }
 	    }
     },
@@ -56,10 +62,10 @@
       },
       "host_controls": {
 		      "DSUClient/1/BetterJoy": {
-				"DSUClient/1/BetterJoy": "..\\#DefaultDevices\\Switch_Joy-Con\\Device\\IconN.png"
+				"DSUClient/1/BetterJoy": "../#DefaultDevices/Switch_Joy-Con/Device/IconN.png"
 			    },
 		      "DSUClient/0/BetterJoy": {
-				"DSUClient/0/BetterJoy": "..\\#DefaultDevices\\Switch_Pro Controller\\Device\\IconN.png"
+				"DSUClient/0/BetterJoy": "../#DefaultDevices/Switch_Pro Controller/Device/IconN.png"
 			    },
 		      "DInput/0/Wireless Gamepad": {
 				"DInput/0/Wireless Gamepad": "..\\#DefaultDevices\\Switch_Pro Controller\\Device\\IconN.png"
@@ -71,10 +77,16 @@
 				"DInput/0/Bluetooth LE XINPUT compatible input device": "..\\#DefaultDevices\\XBOX ONE\\Device\\IconN.png"
 			    },
 		      "DSUClient/0/DualShock4": {
-				"DSUClient/0/DualShock4": "..\\#DefaultDevices\\DualShock4\\Device\\IconN.png"
+				"DSUClient/0/DualShock4": "../#DefaultDevices/DualShock4/Device/IconN.png"
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "..\\#DefaultDevices\\DualShock4\\Device\\IconN.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/IconN.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/IconN.png"
 			    }
 	    }
     }

--- a/Mario Kart Wii/output_Devices.json
+++ b/Mario Kart Wii/output_Devices.json
@@ -37,6 +37,12 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
 			    }
 	    }
     },
@@ -75,6 +81,12 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
 			    }
 	    }
     },
@@ -113,6 +125,12 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
 			    }
 	    }
     },
@@ -151,6 +169,12 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
 			    }
 	    }
     }

--- a/Need for Speed Carbon/output_Devices.json
+++ b/Need for Speed Carbon/output_Devices.json
@@ -37,7 +37,13 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
-			}
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
+			    }
 	    }
 	  
     },
@@ -76,7 +82,13 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
-			}
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
+			    }
 	    }
 	  
     },
@@ -115,7 +127,13 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
-			}
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
+			    }
 	    }
 	  
     },
@@ -154,7 +172,13 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
-			}
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
+			    }
 	    }
 	  
     },
@@ -193,7 +217,13 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
-			}
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
+			    }
 	    }
 	  
     }

--- a/Need for Speed Undercover/output_Devices.json
+++ b/Need for Speed Undercover/output_Devices.json
@@ -37,6 +37,12 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
 			    }
 	    }
     },
@@ -75,6 +81,12 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
 			    }
 	    }
     }

--- a/New Super Mario Wii/output_Devices.json
+++ b/New Super Mario Wii/output_Devices.json
@@ -37,6 +37,12 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
 			    }
 	    }
     },
@@ -75,6 +81,12 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
 			    }
 	    }
     }

--- a/Super Mario Galaxy/output_Devices.json
+++ b/Super Mario Galaxy/output_Devices.json
@@ -22,6 +22,12 @@
 			    },
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "Wiimote Animations/DualShock4/tex1_128x128_2bc2bcb2db441b70_4.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_2bc2bcb2db441b70_4.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_2bc2bcb2db441b70_4.png"
 			    }
 	    }
     },
@@ -45,6 +51,12 @@
 			    },
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "Wiimote Animations/DualShock4/tex1_128x128_75edc338cb298220_4.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_75edc338cb298220_4.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_75edc338cb298220_4.png"
 			    }
 	    }
     },
@@ -68,6 +80,12 @@
 			    },
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "Wiimote Animations/DualShock4/tex1_128x128_715a1feea447461b_4.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_715a1feea447461b_4.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_715a1feea447461b_4.png"
 			    }
 	    }
     },
@@ -91,6 +109,12 @@
 			    },
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "Wiimote Animations/DualShock4/tex1_128x128_847d41fbcf8b308e_4.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_847d41fbcf8b308e_4.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_847d41fbcf8b308e_4.png"
 			    }
 	    }
     },
@@ -114,6 +138,12 @@
 			    },
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "Wiimote Animations/DualShock4/tex1_128x128_5277b75ea1688bd4_4.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_5277b75ea1688bd4_4.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_5277b75ea1688bd4_4.png"
 			    }
 	    }
     },
@@ -137,6 +167,12 @@
 			},
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "Wiimote Animations/DualShock4/tex1_128x128_05692a04cdd9bf97_4.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_05692a04cdd9bf97_4.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_05692a04cdd9bf97_4.png"
 			    }
 	    }
     },
@@ -160,6 +196,12 @@
 			},
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "Wiimote Animations/DualShock4/tex1_128x128_a4fc6558152fbf3f_4.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_a4fc6558152fbf3f_4.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_a4fc6558152fbf3f_4.png"
 			    }
 	    }
     },
@@ -183,6 +225,12 @@
 			},
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "Wiimote Animations/DualShock4/tex1_128x128_be0696b00ef70b9a_4.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_be0696b00ef70b9a_4.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_be0696b00ef70b9a_4.png"
 			    }
 	    }
     },
@@ -206,6 +254,12 @@
 			},
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "Wiimote Animations/DualShock4/tex1_128x128_c165bf4bc64281e7_4.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_c165bf4bc64281e7_4.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_c165bf4bc64281e7_4.png"
 			    }
 	    }
     },
@@ -229,6 +283,12 @@
 			},
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "Wiimote Animations/DualShock4/tex1_128x128_c97659147330c75b_4.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_c97659147330c75b_4.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_c97659147330c75b_4.png"
 			    }
 	    }
     },
@@ -252,6 +312,12 @@
 			},
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "Wiimote Animations/DualShock4/tex1_128x128_cb5bba45b9574b45_4.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_cb5bba45b9574b45_4.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_cb5bba45b9574b45_4.png"
 			    }
 	    }
     },
@@ -275,6 +341,12 @@
 			},
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "Wiimote Animations/DualShock4/tex1_128x128_d2d7f1826bb18c31_4.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_d2d7f1826bb18c31_4.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_d2d7f1826bb18c31_4.png"
 			    }
 	    }
     },
@@ -298,6 +370,12 @@
 			},
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "Wiimote Animations/DualShock4/tex1_128x128_dcf98b2b73c4db9f_4.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_dcf98b2b73c4db9f_4.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "Wiimote Animations/DualShock4/tex1_128x128_dcf98b2b73c4db9f_4.png"
 			    }
 	    }
     }

--- a/Super Mario Strikers/output_Devices.json
+++ b/Super Mario Strikers/output_Devices.json
@@ -33,10 +33,16 @@
 				"DInput/0/Bluetooth LE XINPUT compatible input device": "../#DefaultDevices/XBOX ONE/Device/IconN.png"
 			    },
 		      "DSUClient/0/DualShock4": {
-				"DSUClient/0/DualShock4": "..\\#DefaultDevices\\DualShock4\\Device\\IconN.png"
+				"DSUClient/0/DualShock4": "../#DefaultDevices/DualShock4/Device/IconN.png"
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "..\\#DefaultDevices\\DualShock4\\Device\\IconN.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/IconN.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/IconN.png"
 			    }
 	    }
     }

--- a/Super Monkey Ball 2/output_Devices.json
+++ b/Super Monkey Ball 2/output_Devices.json
@@ -37,6 +37,12 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "..\\#DefaultDevices\\DualShock4\\Device\\Icon.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
 			    }
 	    }
     },
@@ -75,6 +81,12 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "..\\#DefaultDevices\\DualShock4\\Device\\Icon-Simple.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon-Simple.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon-Simple.png"
 			    }
 	    }
     }

--- a/Super Monkey Ball/output_Devices.json
+++ b/Super Monkey Ball/output_Devices.json
@@ -37,6 +37,12 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "..\\#DefaultDevices\\DualShock4\\Device\\Icon.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
 			    }
 	    }
     }

--- a/Super Smash Bros Brawl/output_Devices.json
+++ b/Super Smash Bros Brawl/output_Devices.json
@@ -37,6 +37,12 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front.png"
 			    }
 	    }
     },
@@ -75,6 +81,12 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
 			    }
 	    }
     },
@@ -113,6 +125,12 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon-SimpleN.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon-SimpleN.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon-SimpleN.png"
 			    }
 	    }
     },
@@ -151,6 +169,12 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
 			    }
 	    }
     },
@@ -189,6 +213,12 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
 			    }
 	    }
     },
@@ -227,6 +257,12 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
 			    }
 	    }
     },

--- a/Wii Sports/output_Devices.json
+++ b/Wii Sports/output_Devices.json
@@ -37,6 +37,12 @@
 			    },
 		      "DInput/0/Wireless Controller": {
 				"DInput/0/Wireless Controller": "..\\#DefaultDevices\\DualShock4\\Device\\3D-front from above.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
 			    }
 	    }
     }

--- a/Zelda Skyward Sword/output_Devices.json
+++ b/Zelda Skyward Sword/output_Devices.json
@@ -25,6 +25,12 @@
 			    },
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "../#DefaultDevices/DualShock4/Device/Move.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move.png"
 			    }
 	    }
     },
@@ -48,6 +54,12 @@
 			    },
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "../#DefaultDevices/DualShock4/Device/Move_Pointer_Up.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Pointer_Up.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Pointer_Up.png"
 			    }
 	    }
     },
@@ -71,6 +83,12 @@
 			    },
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "../#DefaultDevices/DualShock4/Device/Icon-Simple_90.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon-Simple_90.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon-Simple_90.png"
 			    }
 	    }
     },
@@ -94,6 +112,12 @@
 			    },
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "../#DefaultDevices/DualShock4/Device/Move_Pointer_Right.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Pointer_Right.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Pointer_Right.png"
 			    }
 	    }
     },
@@ -117,6 +141,12 @@
 			    },
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "../#DefaultDevices/DualShock4/Device/Move_Pointer_Down.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Pointer_Down.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Pointer_Down.png"
 			    }
 	    }
     },
@@ -140,6 +170,12 @@
 			    },
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "../#DefaultDevices/DualShock4/Device/Move_Pointer_Center.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Pointer_Center.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Pointer_Center.png"
 			    }
 	    }
     },
@@ -163,6 +199,12 @@
 			    },
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "../#DefaultDevices/DualShock4/Device/Move_Pointer_Up.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Pointer_Up.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Pointer_Up.png"
 			    }
 	    }
     },
@@ -186,6 +228,12 @@
 			    },
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "../#DefaultDevices/DualShock4/Device/Move_Pointer_Left.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Pointer_Left.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Pointer_Left.png"
 			    }
 	    }
     },
@@ -209,6 +257,12 @@
 			    },
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "../#DefaultDevices/DualShock4/Device/Move_Pointer_RightUp.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Pointer_RightUp.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Pointer_RightUp.png"
 			    }
 	    }
     },
@@ -232,6 +286,12 @@
 			    },
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "../#DefaultDevices/DualShock4/Device/Move_Pointer_Right.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Pointer_Right.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Pointer_Right.png"
 			    }
 	    }
     },
@@ -335,6 +395,12 @@
 			    },
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "../#DefaultDevices/DualShock4/Device/Move_Deep_Down.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Deep_Down.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Deep_Down.png"
 			    }
 	    }
     },
@@ -358,6 +424,12 @@
 			    },
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "../#DefaultDevices/DualShock4/Device/Move_Deep_Up.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Deep_Up.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Deep_Up.png"
 			    }
 	    }
     },
@@ -381,6 +453,12 @@
 			    },
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "../#DefaultDevices/DualShock4/Device/Move_180.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_180.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_180.png"
 			    }
 	    }
     },
@@ -404,6 +482,12 @@
 			    },
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "../#DefaultDevices/DualShock4/Device/Move_90.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_90.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_90.png"
 			    }
 	    }
     },
@@ -427,6 +511,12 @@
 			    },
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "../#DefaultDevices/DualShock4/Device/Move_Roll_Left.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Roll_Left.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Roll_Left.png"
 			    }
 	    }
     },
@@ -450,6 +540,12 @@
 			    },
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "../#DefaultDevices/DualShock4/Device/Move_Roll_Left.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Roll_Left.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Roll_Left.png"
 			    }
 	    }
     },
@@ -473,6 +569,12 @@
 			    },
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "../#DefaultDevices/DualShock4/Device/Move_Roll_Left.png"
+			    },
+		      "evdev/0/Wireless Controller": {
+				"evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Roll_Left.png"
+			    },
+		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
+				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Move_Roll_Left.png"
 			    }
 	    }
     }


### PR DESCRIPTION
Added device and motion control images for DS4 via `evdev/0/Wireless Controller` and `evdev/0/Sony Interactive Entertainment Wireless Controller` for packs that already had them. I did this by hand and haven't tested any of them, so please be on the lookout for mistakes.

I have noticed that some packs have had `\\` changed to `/` even for Windows-only devices. There were also some small mistakes with this that I have corrected (e.g. for Mario Kart Double Dash).

I will probably do the same for xbox controllers at some point.