### PR TITLE
Add Linux Xbox device image support

### DIFF
--- a/F-ZERO GX/output_Devices.json
+++ b/F-ZERO GX/output_Devices.json
@@ -43,6 +43,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/3D-front.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/3D-front.png"
 			    }
 	    }
     }

--- a/Kirby Air Ride/output_Devices.json
+++ b/Kirby Air Ride/output_Devices.json
@@ -43,6 +43,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon-Simple.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon-Simple.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/Icon-Simple.png"
 			    }
 	    }
     },
@@ -87,6 +93,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon-Simple.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon-Simple.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/Icon-Simple.png"
 			    }
 	    }
     }

--- a/Mario Kart Double Dash/output_Devices.json
+++ b/Mario Kart Double Dash/output_Devices.json
@@ -43,6 +43,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/IconN.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/IconN.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/IconN.png"
 			    }
 	    }
     },
@@ -87,6 +93,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/IconN.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/IconN.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/IconN.png"
 			    }
 	    }
     }

--- a/Mario Kart Wii/output_Devices.json
+++ b/Mario Kart Wii/output_Devices.json
@@ -43,6 +43,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png"
 			    }
 	    }
     },
@@ -87,6 +93,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png"
 			    }
 	    }
     },
@@ -131,6 +143,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png"
 			    }
 	    }
     },
@@ -175,6 +193,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png"
 			    }
 	    }
     }

--- a/Need for Speed Carbon/output_Devices.json
+++ b/Need for Speed Carbon/output_Devices.json
@@ -43,6 +43,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/3D-front from above.png"
 			    }
 	    }
 	  
@@ -88,6 +94,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/3D-front from above.png"
 			    }
 	    }
 	  
@@ -133,6 +145,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/3D-front from above.png"
 			    }
 	    }
 	  
@@ -178,6 +196,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/3D-front from above.png"
 			    }
 	    }
 	  
@@ -223,6 +247,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/3D-front from above.png"
 			    }
 	    }
 	  

--- a/Need for Speed Undercover/output_Devices.json
+++ b/Need for Speed Undercover/output_Devices.json
@@ -43,6 +43,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png"
 			    }
 	    }
     },
@@ -87,6 +93,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/3D-front from above.png"
 			    }
 	    }
     }

--- a/New Super Mario Wii/output_Devices.json
+++ b/New Super Mario Wii/output_Devices.json
@@ -43,6 +43,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png"
 			    }
 	    }
     },
@@ -87,6 +93,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png"
 			    }
 	    }
     }

--- a/Super Mario Strikers/output_Devices.json
+++ b/Super Mario Strikers/output_Devices.json
@@ -30,7 +30,7 @@
 				"XInput/0/Gamepad": "..\\#DefaultDevices\\XBOX ONE\\Device\\IconN.png"
 			    },
 		      "DInput/0/Bluetooth LE XINPUT compatible input device": {
-				"DInput/0/Bluetooth LE XINPUT compatible input device": "../#DefaultDevices/XBOX ONE/Device/IconN.png"
+				"DInput/0/Bluetooth LE XINPUT compatible input device": "..\\#DefaultDevices\\XBOX ONE\\Device\\IconN.png"
 			    },
 		      "DSUClient/0/DualShock4": {
 				"DSUClient/0/DualShock4": "../#DefaultDevices/DualShock4/Device/IconN.png"
@@ -43,6 +43,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/IconN.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/IconN.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/IconN.png"
 			    }
 	    }
     }

--- a/Super Monkey Ball 2/output_Devices.json
+++ b/Super Monkey Ball 2/output_Devices.json
@@ -43,6 +43,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png"
 			    }
 	    }
     },
@@ -87,6 +93,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon-Simple.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon-Simple.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/Icon-Simple.png"
 			    }
 	    }
     }

--- a/Super Monkey Ball/output_Devices.json
+++ b/Super Monkey Ball/output_Devices.json
@@ -43,6 +43,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png"
 			    }
 	    }
     }

--- a/Super Smash Bros Brawl/output_Devices.json
+++ b/Super Smash Bros Brawl/output_Devices.json
@@ -43,6 +43,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/3D-front.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/3D-front.png"
 			    }
 	    }
     },
@@ -87,6 +93,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png"
 			    }
 	    }
     },
@@ -131,6 +143,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon-SimpleN.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon-SimpleN.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/Icon-SimpleN.png"
 			    }
 	    }
     },
@@ -175,6 +193,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/3D-front from above.png"
 			    }
 	    }
     },
@@ -219,6 +243,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png"
 			    }
 	    }
     },
@@ -263,6 +293,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png"
 			    }
 	    }
     },

--- a/Wii Sports/output_Devices.json
+++ b/Wii Sports/output_Devices.json
@@ -43,6 +43,12 @@
 			    },
 		      "evdev/0/Sony Interactive Entertainment Wireless Controller": {
 				"evdev/0/Sony Interactive Entertainment Wireless Controller": "../#DefaultDevices/DualShock4/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Microsoft X-Box 360 pad": {
+				"evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/3D-front from above.png"
+			    },
+		      "evdev/0/Microsoft X-Box One S pad": {
+				"evdev/0/Microsoft X-Box One S pad": "../#DefaultDevices/XBOX ONE/Device/3D-front from above.png"
 			    }
 	    }
     }


### PR DESCRIPTION
Continues #10, this time for `evdev/0/Microsoft X-Box 360 pad` and `evdev/0/Microsoft X-Box One S pad`