### PR TITLE
Fix generated folder name in NfS Underground

### DIFF
--- a/Need for Speed Underground/UniversalDIT_Simple-Default_EX.json
+++ b/Need for Speed Underground/UniversalDIT_Simple-Default_EX.json
@@ -865,6 +865,7 @@
       "`Keypad =`": "../#DefaultDevices/Keyboard Mouse/Simple-Default/EQUALS.png"
     }
   },
+  "generated_folder_name": "#Generated_Need for Speed Underground",
   "preserve_aspect_ratio": true,
   "output_textures": {
     "tex1_32x32_m_4d210bea40ab98b0_e8e7974e4e09e526_9.png": {


### PR DESCRIPTION
Adds a line that has been missing before and that made dolphin name the folder after gameid