### PR TITLE
Fix Thumb L/R for Xbox pads on Linux

### DIFF
--- a/#Assets/UniversalDIT_Defaultstyle.json
+++ b/#Assets/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/#Assets/UniversalDIT_Defaultstyle_Pressed.json
+++ b/#Assets/UniversalDIT_Defaultstyle_Pressed.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Defaultstyle_Pressed/Cross.png",

--- a/#Assets/UniversalDIT_Flat.json
+++ b/#Assets/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/#Assets/UniversalDIT_Flat_Pressed.json
+++ b/#Assets/UniversalDIT_Flat_Pressed.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Flat_Pressed/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Flat_Pressed/Cross.png",

--- a/#Assets/UniversalDIT_Mirror_Defaultstyle.json
+++ b/#Assets/UniversalDIT_Mirror_Defaultstyle.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Defaultstyle/Cross.png",

--- a/#Assets/UniversalDIT_Mirror_Defaultstyle_Pressed.json
+++ b/#Assets/UniversalDIT_Mirror_Defaultstyle_Pressed.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Defaultstyle_Pressed/Cross.png",

--- a/#Assets/UniversalDIT_Mirror_Flat.json
+++ b/#Assets/UniversalDIT_Mirror_Flat.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Flat/Cross.png",

--- a/#Assets/UniversalDIT_Mirror_Flat_Pressed.json
+++ b/#Assets/UniversalDIT_Mirror_Flat_Pressed.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Flat_Pressed/Cross.png",

--- a/#Assets/UniversalDIT_Mirror_Simple-Default.json
+++ b/#Assets/UniversalDIT_Mirror_Simple-Default.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Simple-Default/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Simple-Default/Cross.png",

--- a/#Assets/UniversalDIT_Mirror_Simple-Default_EX.json
+++ b/#Assets/UniversalDIT_Mirror_Simple-Default_EX.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Simple-Default/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Simple-Default/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Simple-Default/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Simple-Default/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Simple-Default/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Simple-Default/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Simple-Default/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Simple-Default/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Simple-Default/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Simple-Default/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Simple-Default/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Simple-Default/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Simple-Default/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Simple-Default/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Simple-Default/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Simple-Default/Cross.png",

--- a/#Assets/UniversalDIT_Mirror_Text-Default.json
+++ b/#Assets/UniversalDIT_Mirror_Text-Default.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Text-Default/Cross.png",

--- a/#Assets/UniversalDIT_Mirror_Text-Outlines.json
+++ b/#Assets/UniversalDIT_Mirror_Text-Outlines.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Outlines/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Outlines/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Outlines/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Outlines/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Outlines/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Outlines/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Outlines/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Outlines/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Outlines/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Outlines/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Outlines/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Text-Outlines/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Outlines/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Outlines/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Outlines/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Text-Outlines/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Text-Outlines/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Outlines/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Outlines/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Outlines/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Outlines/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Text-Outlines/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Text-Outlines/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Text-Outlines/Cross.png",

--- a/#Assets/UniversalDIT_Simple-Default.json
+++ b/#Assets/UniversalDIT_Simple-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/#Assets/UniversalDIT_Simple-Default_EX.json
+++ b/#Assets/UniversalDIT_Simple-Default_EX.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Simple-Default/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Simple-Default/Cross.png",

--- a/#Assets/UniversalDIT_Text-Default.json
+++ b/#Assets/UniversalDIT_Text-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Text-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Text-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Text-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Text-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Text-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Text-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Text-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Text-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Text-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Text-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Text-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Text-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Text-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Text-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/#Assets/UniversalDIT_Text-Outlines.json
+++ b/#Assets/UniversalDIT_Text-Outlines.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Animal Crossing Wii/UniversalDIT_Simple-Default.json
+++ b/Animal Crossing Wii/UniversalDIT_Simple-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Baten Kaitos Eternal Wings/UniversalDIT_Flat.json
+++ b/Baten Kaitos Eternal Wings/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Beat the Beat/UniversalDIT_Defaultstyle.json
+++ b/Beat the Beat/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Beat the Beat/UniversalDIT_Simple-Default.json
+++ b/Beat the Beat/UniversalDIT_Simple-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Beyond Good & Evil/UniversalDIT_Flat_Mirror.json
+++ b/Beyond Good & Evil/UniversalDIT_Flat_Mirror.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Flat/Cross.png",

--- a/Bomberman Blast/UniversalDIT_Flat.json
+++ b/Bomberman Blast/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Bomberman Blast/UniversalDIT_Text-Outlines.json
+++ b/Bomberman Blast/UniversalDIT_Text-Outlines.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Boom Street/UniversalDIT_Flat.json
+++ b/Boom Street/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Castlevania Judgment/UniversalDIT_Flat.json
+++ b/Castlevania Judgment/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Chibi-Robo/UniversalDIT_Flat.json
+++ b/Chibi-Robo/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Chibi-Robo/UniversalDIT_Flat_Pressed.json
+++ b/Chibi-Robo/UniversalDIT_Flat_Pressed.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Flat_Pressed/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Flat_Pressed/Cross.png",

--- a/Dancing Stage Mario Mix/UniversalDIT_Defaultstyle.json
+++ b/Dancing Stage Mario Mix/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Digimon World 4/UniversalDIT_Mirror_Flat.json
+++ b/Digimon World 4/UniversalDIT_Mirror_Flat.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Defaultstyle/Cross.png",

--- a/Dokapon Kingdom/UniversalDIT_Flat.json
+++ b/Dokapon Kingdom/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Donkey Kong Country Returns/UniversalDIT_Defaultstyle_Mirror.json
+++ b/Donkey Kong Country Returns/UniversalDIT_Defaultstyle_Mirror.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Defaultstyle/Cross.png",

--- a/Donkey Kong Country Returns/UniversalDIT_Defaultstyle_Mirror_info.json
+++ b/Donkey Kong Country Returns/UniversalDIT_Defaultstyle_Mirror_info.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Defaultstyle/Cross.png",

--- a/Donkey Kong Country Returns/UniversalDIT_Defaultstyle_Pressed_Mirror.json
+++ b/Donkey Kong Country Returns/UniversalDIT_Defaultstyle_Pressed_Mirror.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Defaultstyle_Pressed/Cross.png",

--- a/Donkey Kong Country Returns/UniversalDIT_Defaultstyle_Pressed_Mirror_info.json
+++ b/Donkey Kong Country Returns/UniversalDIT_Defaultstyle_Pressed_Mirror_info.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Defaultstyle_Pressed/Cross.png",

--- a/Donkey Kong Jet Race/UniversalDIT_Defaultstyle.json
+++ b/Donkey Kong Jet Race/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Donkey Kong Jet Race/UniversalDIT_Flat.json
+++ b/Donkey Kong Jet Race/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Doshin the Giant/UniversalDIT_Flat.json
+++ b/Doshin the Giant/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Dragon Ball Revenge of King Piccolo/UniversalDIT_Flat.json
+++ b/Dragon Ball Revenge of King Piccolo/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Dragon Ball Z Budokai Tenkaichi 3/UniversalDIT_Defaultstyle.json
+++ b/Dragon Ball Z Budokai Tenkaichi 3/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Dragon Ball Z Budokai Tenkaichi 3/UniversalDIT_Defaultstyle_Pressed.json
+++ b/Dragon Ball Z Budokai Tenkaichi 3/UniversalDIT_Defaultstyle_Pressed.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Defaultstyle_Pressed/Cross.png",

--- a/Dragon Ball Z Sagas/UniversalDIT_Flat.json
+++ b/Dragon Ball Z Sagas/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Dragon Ball Z Sagas/UniversalDIT_Flat_Pressed.json
+++ b/Dragon Ball Z Sagas/UniversalDIT_Flat_Pressed.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Eternal Darkness/UniversalDIT_Flat_Mirror.json
+++ b/Eternal Darkness/UniversalDIT_Flat_Mirror.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Flat/Cross.png",

--- a/Excite Truck/UniversalDIT_Defaultstyle.json
+++ b/Excite Truck/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Excite Truck/UniversalDIT_Text-Outlines.json
+++ b/Excite Truck/UniversalDIT_Text-Outlines.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/F-ZERO GX/UniversalDIT_Flat.json
+++ b/F-ZERO GX/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/FAST Racing League/UniversalDIT_Flat.json
+++ b/FAST Racing League/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/FFCC Crystal Bearers/UniversalDIT_Simple-Default.json
+++ b/FFCC Crystal Bearers/UniversalDIT_Simple-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/FFCC Crystal Bearers/UniversalDIT_Simple-Default_EX.json
+++ b/FFCC Crystal Bearers/UniversalDIT_Simple-Default_EX.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Simple-Default/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Simple-Default/Cross.png",

--- a/FIFA 15 Legacy Edition/UniversalDIT_Flat.json
+++ b/FIFA 15 Legacy Edition/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/FIFA 15 Legacy Edition/UniversalDIT_Simple-Default.json
+++ b/FIFA 15 Legacy Edition/UniversalDIT_Simple-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/FIFA 15 Legacy Edition/UniversalDIT_Simple-Default_Overlay.json
+++ b/FIFA 15 Legacy Edition/UniversalDIT_Simple-Default_Overlay.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Fire Emblem Path of Radiance/UniversalDIT_Flat.json
+++ b/Fire Emblem Path of Radiance/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Fire Emblem Radiant Dawn/UniversalDIT_Flat.json
+++ b/Fire Emblem Radiant Dawn/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Fragile Dreams/UniversalDIT_Flat.json
+++ b/Fragile Dreams/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Fragile Dreams/UniversalDIT_Simple-Default.json
+++ b/Fragile Dreams/UniversalDIT_Simple-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/GameCube Menu/UniversalDIT_Defaultstyle.json
+++ b/GameCube Menu/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/GameCube Menu/UniversalDIT_Defaultstyle_Pressed.json
+++ b/GameCube Menu/UniversalDIT_Defaultstyle_Pressed.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Defaultstyle_Pressed/Cross.png",

--- a/GameCube Menu/UniversalDIT_Text-Default.json
+++ b/GameCube Menu/UniversalDIT_Text-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Text-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Text-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Text-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Text-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Text-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Text-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Text-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Text-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Text-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Text-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Text-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Text-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Text-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Text-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Harvest Moon A Proud Life/UniversalDIT_Defaultstyle.json
+++ b/Harvest Moon A Proud Life/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Harvest Moon A Wonderful Life_DE/UniversalDIT_Defaultstyle.json
+++ b/Harvest Moon A Wonderful Life_DE/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Harvest Moon A Wonderful Life_EN/UniversalDIT_Defaultstyle.json
+++ b/Harvest Moon A Wonderful Life_EN/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Harvest Moon Another Proud Life/UniversalDIT_Defaultstyle.json
+++ b/Harvest Moon Another Proud Life/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Harvest Moon Another Wonderful Life/UniversalDIT_Defaultstyle.json
+++ b/Harvest Moon Another Wonderful Life/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Jett Rocket/UniversalDIT_flat.json
+++ b/Jett Rocket/UniversalDIT_flat.json
@@ -477,12 +477,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -505,12 +505,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Kirby Air Ride/UniversalDIT_Flat.json
+++ b/Kirby Air Ride/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Kirbys Return To Dreamland/UniversalDIT_Flat.json
+++ b/Kirbys Return To Dreamland/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Kirbys Return To Dreamland/UniversalDIT_Flat_Pressed.json
+++ b/Kirbys Return To Dreamland/UniversalDIT_Flat_Pressed.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Flat_Pressed/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Flat_Pressed/Cross.png",

--- a/Luigis Mansion/UniversalDIT_Text-Outlines.json
+++ b/Luigis Mansion/UniversalDIT_Text-Outlines.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Mario Golf Toadstool Tour/UniversalDIT_Flat.json
+++ b/Mario Golf Toadstool Tour/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Mario Golf Toadstool Tour/UniversalDIT_Flat_Pressed.json
+++ b/Mario Golf Toadstool Tour/UniversalDIT_Flat_Pressed.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Flat_Pressed/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Flat_Pressed/Cross.png",

--- a/Mario Kart Double Dash/UniversalDIT_Flat.json
+++ b/Mario Kart Double Dash/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Mario Kart Wii/UniversalDIT_Flat.json
+++ b/Mario Kart Wii/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Mario Party 2/UniversalDIT_Flat.json
+++ b/Mario Party 2/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Mario Party 2/UniversalDIT_ShyGuyRed.json
+++ b/Mario Party 2/UniversalDIT_ShyGuyRed.json
@@ -469,12 +469,12 @@
       "`Axis 1+`": "ShyGuy_Red/XBOX ONE/Left Y-.png",
       "`Axis 0+`": "ShyGuy_Red/XBOX ONE/Left X+.png",
       "`Axis 0-`": "ShyGuy_Red/XBOX ONE/Left X-.png",
-      "THUMBR": "ShyGuy_Red/XBOX ONE/Thumb L.png",
+      "THUMBR": "ShyGuy_Red/XBOX ONE/Thumb R.png",
       "`Axis 4-`": "ShyGuy_Red/XBOX ONE/Right Y+.png",
       "`Axis 4+`": "ShyGuy_Red/XBOX ONE/Right Y-.png",
       "`Axis 3+`": "ShyGuy_Red/XBOX ONE/Right X+.png",
       "`Axis 3-`": "ShyGuy_Red/XBOX ONE/Right X-.png",
-      "THUMBL": "ShyGuy_Red/XBOX ONE/Thumb R.png"
+      "THUMBL": "ShyGuy_Red/XBOX ONE/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "ShyGuy_Red/XBOX ONE/Button A.png",
@@ -496,12 +496,12 @@
       "`Axis 1+`": "ShyGuy_Red/XBOX ONE/Left Y-.png",
       "`Axis 0+`": "ShyGuy_Red/XBOX ONE/Left X+.png",
       "`Axis 0-`": "ShyGuy_Red/XBOX ONE/Left X-.png",
-      "THUMBR": "ShyGuy_Red/XBOX ONE/Thumb L.png",
+      "THUMBR": "ShyGuy_Red/XBOX ONE/Thumb R.png",
       "`Axis 4-`": "ShyGuy_Red/XBOX ONE/Right Y+.png",
       "`Axis 4+`": "ShyGuy_Red/XBOX ONE/Right Y-.png",
       "`Axis 3+`": "ShyGuy_Red/XBOX ONE/Right X+.png",
       "`Axis 3-`": "ShyGuy_Red/XBOX ONE/Right X-.png",
-      "THUMBL": "ShyGuy_Red/XBOX ONE/Thumb R.png"
+      "THUMBL": "ShyGuy_Red/XBOX ONE/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "ShyGuy_Red/DualShock4/Cross.png",

--- a/Mario Party 2/UniversalDIT_ShyGuyWhite.json
+++ b/Mario Party 2/UniversalDIT_ShyGuyWhite.json
@@ -469,12 +469,12 @@
       "`Axis 1+`": "ShyGuy_White/XBOX ONE/Left Y-.png",
       "`Axis 0+`": "ShyGuy_White/XBOX ONE/Left X+.png",
       "`Axis 0-`": "ShyGuy_White/XBOX ONE/Left X-.png",
-      "THUMBR": "ShyGuy_White/XBOX ONE/Thumb L.png",
+      "THUMBR": "ShyGuy_White/XBOX ONE/Thumb R.png",
       "`Axis 4-`": "ShyGuy_White/XBOX ONE/Right Y+.png",
       "`Axis 4+`": "ShyGuy_White/XBOX ONE/Right Y-.png",
       "`Axis 3+`": "ShyGuy_White/XBOX ONE/Right X+.png",
       "`Axis 3-`": "ShyGuy_White/XBOX ONE/Right X-.png",
-      "THUMBL": "ShyGuy_White/XBOX ONE/Thumb R.png"
+      "THUMBL": "ShyGuy_White/XBOX ONE/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "ShyGuy_White/XBOX ONE/Button A.png",
@@ -496,12 +496,12 @@
       "`Axis 1+`": "ShyGuy_White/XBOX ONE/Left Y-.png",
       "`Axis 0+`": "ShyGuy_White/XBOX ONE/Left X+.png",
       "`Axis 0-`": "ShyGuy_White/XBOX ONE/Left X-.png",
-      "THUMBR": "ShyGuy_White/XBOX ONE/Thumb L.png",
+      "THUMBR": "ShyGuy_White/XBOX ONE/Thumb R.png",
       "`Axis 4-`": "ShyGuy_White/XBOX ONE/Right Y+.png",
       "`Axis 4+`": "ShyGuy_White/XBOX ONE/Right Y-.png",
       "`Axis 3+`": "ShyGuy_White/XBOX ONE/Right X+.png",
       "`Axis 3-`": "ShyGuy_White/XBOX ONE/Right X-.png",
-      "THUMBL": "ShyGuy_White/XBOX ONE/Thumb R.png"
+      "THUMBL": "ShyGuy_White/XBOX ONE/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "ShyGuy_White/DualShock4/Cross.png",

--- a/Mario Party 4/UniversalDIT_Defaultstyle.json
+++ b/Mario Party 4/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Mario Party 5/UniversalDIT_Defaultstyle.json
+++ b/Mario Party 5/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Mario Party 5/UniversalDIT_Flat.json
+++ b/Mario Party 5/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Mario Party 5/UniversalDIT_ShyGuy.json
+++ b/Mario Party 5/UniversalDIT_ShyGuy.json
@@ -452,12 +452,12 @@
       "`Axis 1+`": "ShyGuy/XBOX ONE/Left Y-.png",
       "`Axis 0+`": "ShyGuy/XBOX ONE/Left X+.png",
       "`Axis 0-`": "ShyGuy/XBOX ONE/Left X-.png",
-      "THUMBR": "ShyGuy/XBOX ONE/Thumb L.png",
+      "THUMBR": "ShyGuy/XBOX ONE/Thumb R.png",
       "`Axis 4-`": "ShyGuy/XBOX ONE/Right Y+.png",
       "`Axis 4+`": "ShyGuy/XBOX ONE/Right Y-.png",
       "`Axis 3+`": "ShyGuy/XBOX ONE/Right X+.png",
       "`Axis 3-`": "ShyGuy/XBOX ONE/Right X-.png",
-      "THUMBL": "ShyGuy/XBOX ONE/Thumb R.png"
+      "THUMBL": "ShyGuy/XBOX ONE/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "ShyGuy/XBOX ONE/Button A.png",
@@ -479,12 +479,12 @@
       "`Axis 1+`": "ShyGuy/XBOX ONE/Left Y-.png",
       "`Axis 0+`": "ShyGuy/XBOX ONE/Left X+.png",
       "`Axis 0-`": "ShyGuy/XBOX ONE/Left X-.png",
-      "THUMBR": "ShyGuy/XBOX ONE/Thumb L.png",
+      "THUMBR": "ShyGuy/XBOX ONE/Thumb R.png",
       "`Axis 4-`": "ShyGuy/XBOX ONE/Right Y+.png",
       "`Axis 4+`": "ShyGuy/XBOX ONE/Right Y-.png",
       "`Axis 3+`": "ShyGuy/XBOX ONE/Right X+.png",
       "`Axis 3-`": "ShyGuy/XBOX ONE/Right X-.png",
-      "THUMBL": "ShyGuy/XBOX ONE/Thumb R.png"
+      "THUMBL": "ShyGuy/XBOX ONE/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "ShyGuy/DualShock4/Cross.png",

--- a/Mario Party 6/UniversalDIT_Defaultstyle.json
+++ b/Mario Party 6/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Mario Party 6/UniversalDIT_Defaultstyle_Pressed.json
+++ b/Mario Party 6/UniversalDIT_Defaultstyle_Pressed.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Defaultstyle_Pressed/Cross.png",

--- a/Mario Party 6/UniversalDIT_Flat.json
+++ b/Mario Party 6/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Mario Party 7/UniversalDIT_Defaultstyle.json
+++ b/Mario Party 7/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Mario Party 7/UniversalDIT_Defaultstyle_90.json
+++ b/Mario Party 7/UniversalDIT_Defaultstyle_90.json
@@ -477,12 +477,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -505,12 +505,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Mario Party 7/UniversalDIT_Defaultstyle_Pressed.json
+++ b/Mario Party 7/UniversalDIT_Defaultstyle_Pressed.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Defaultstyle_Pressed/Cross.png",

--- a/Mario Party 8/UniversalDIT_Flat.json
+++ b/Mario Party 8/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Mario Party 9/UniversalDIT_BombBattle.json
+++ b/Mario Party 9/UniversalDIT_BombBattle.json
@@ -469,12 +469,12 @@
       "`Axis 1+`": "BombBattle/XBOX ONE/Left Y-.png",
       "`Axis 0+`": "BombBattle/XBOX ONE/Left X+.png",
       "`Axis 0-`": "BombBattle/XBOX ONE/Left X-.png",
-      "THUMBR": "BombBattle/XBOX ONE/Thumb L.png",
+      "THUMBR": "BombBattle/XBOX ONE/Thumb R.png",
       "`Axis 4-`": "BombBattle/XBOX ONE/Right Y+.png",
       "`Axis 4+`": "BombBattle/XBOX ONE/Right Y-.png",
       "`Axis 3+`": "BombBattle/XBOX ONE/Right X+.png",
       "`Axis 3-`": "BombBattle/XBOX ONE/Right X-.png",
-      "THUMBL": "BombBattle/XBOX ONE/Thumb R.png"
+      "THUMBL": "BombBattle/XBOX ONE/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "BombBattle/XBOX ONE/Button A.png",
@@ -496,12 +496,12 @@
       "`Axis 1+`": "BombBattle/XBOX ONE/Left Y-.png",
       "`Axis 0+`": "BombBattle/XBOX ONE/Left X+.png",
       "`Axis 0-`": "BombBattle/XBOX ONE/Left X-.png",
-      "THUMBR": "BombBattle/XBOX ONE/Thumb L.png",
+      "THUMBR": "BombBattle/XBOX ONE/Thumb R.png",
       "`Axis 4-`": "BombBattle/XBOX ONE/Right Y+.png",
       "`Axis 4+`": "BombBattle/XBOX ONE/Right Y-.png",
       "`Axis 3+`": "BombBattle/XBOX ONE/Right X+.png",
       "`Axis 3-`": "BombBattle/XBOX ONE/Right X-.png",
-      "THUMBL": "BombBattle/XBOX ONE/Thumb R.png"
+      "THUMBL": "BombBattle/XBOX ONE/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "BombBattle/DualShock4/Cross.png",

--- a/Mario Party 9/UniversalDIT_Defaultstyle.json
+++ b/Mario Party 9/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Mario Party 9/UniversalDIT_Flat.json
+++ b/Mario Party 9/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Mario Party 9/UniversalDIT_Flat_Pressed.json
+++ b/Mario Party 9/UniversalDIT_Flat_Pressed.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Flat_Pressed/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Flat_Pressed/Cross.png",

--- a/Mario Party 9/UniversalDIT_GrowingUP.json
+++ b/Mario Party 9/UniversalDIT_GrowingUP.json
@@ -469,12 +469,12 @@
       "`Axis 1+`": "GrowingUP/XBOX ONE/Left Stick.png",
       "`Axis 0+`": "GrowingUP/XBOX ONE/Left Stick.png",
       "`Axis 0-`": "GrowingUP/XBOX ONE/Left Stick.png",
-      "THUMBR": "GrowingUP/XBOX ONE/Thumb L.png",
+      "THUMBR": "GrowingUP/XBOX ONE/Thumb R.png",
       "`Axis 4-`": "GrowingUP/XBOX ONE/Right Stick.png",
       "`Axis 4+`": "GrowingUP/XBOX ONE/Right Stick.png",
       "`Axis 3+`": "GrowingUP/XBOX ONE/Right Stick.png",
       "`Axis 3-`": "GrowingUP/XBOX ONE/Right Stick.png",
-      "THUMBL": "GrowingUP/XBOX ONE/Thumb R.png"
+      "THUMBL": "GrowingUP/XBOX ONE/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "GrowingUP/XBOX ONE/Button A.png",
@@ -496,12 +496,12 @@
       "`Axis 1+`": "GrowingUP/XBOX ONE/Left Stick.png",
       "`Axis 0+`": "GrowingUP/XBOX ONE/Left Stick.png",
       "`Axis 0-`": "GrowingUP/XBOX ONE/Left Stick.png",
-      "THUMBR": "GrowingUP/XBOX ONE/Thumb L.png",
+      "THUMBR": "GrowingUP/XBOX ONE/Thumb R.png",
       "`Axis 4-`": "GrowingUP/XBOX ONE/Right Stick.png",
       "`Axis 4+`": "GrowingUP/XBOX ONE/Right Stick.png",
       "`Axis 3+`": "GrowingUP/XBOX ONE/Right Stick.png",
       "`Axis 3-`": "GrowingUP/XBOX ONE/Right Stick.png",
-      "THUMBL": "GrowingUP/XBOX ONE/Thumb R.png"
+      "THUMBL": "GrowingUP/XBOX ONE/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "GrowingUP/DualShock4/Cross.png",

--- a/Mario Party 9/UniversalDIT_Simple-Default.json
+++ b/Mario Party 9/UniversalDIT_Simple-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Mario Power Tennis/UniversalDIT_Flat.json
+++ b/Mario Power Tennis/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Mario Strikers Charged/UniversalDIT_Flat.json
+++ b/Mario Strikers Charged/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Mario Superstar Baseball/UniversalDIT_Flat.json
+++ b/Mario Superstar Baseball/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Metroid Other M/UniversalDIT_Simple-Default.json
+++ b/Metroid Other M/UniversalDIT_Simple-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Metroid Other M/UniversalDIT_Text-Default.json
+++ b/Metroid Other M/UniversalDIT_Text-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Text-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Text-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Text-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Text-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Text-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Text-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Text-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Text-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Text-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Text-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Text-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Text-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Text-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Text-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Metroid Prime_GC/UniversalDIT_Flat_Mirror.json
+++ b/Metroid Prime_GC/UniversalDIT_Flat_Mirror.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Flat/Cross.png",

--- a/Metroid Prime_GC/UniversalDIT_Flat_Pressed_Mirror.json
+++ b/Metroid Prime_GC/UniversalDIT_Flat_Pressed_Mirror.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Flat_Pressed/Cross.png",

--- a/Metroid Prime_GC/UniversalDIT_Text-Default_Mirror.json
+++ b/Metroid Prime_GC/UniversalDIT_Text-Default_Mirror.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Text-Default/Cross.png",

--- a/Metroid Prime_Wii/UniversalDIT_Flat_Mirror.json
+++ b/Metroid Prime_Wii/UniversalDIT_Flat_Mirror.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Flat/Cross.png",

--- a/Metroid Prime_Wii/UniversalDIT_Flat_Pressed_Mirror.json
+++ b/Metroid Prime_Wii/UniversalDIT_Flat_Pressed_Mirror.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Flat_Pressed/Cross.png",

--- a/Metroid Prime_Wii/UniversalDIT_Text-Default_Mirror.json
+++ b/Metroid Prime_Wii/UniversalDIT_Text-Default_Mirror.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Text-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Text-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Text-Default/Cross.png",

--- a/Mii Channel/UniversalDIT_Simple-Default.json
+++ b/Mii Channel/UniversalDIT_Simple-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Muramasa The Demon Blade/UniversalDIT_Flat.json
+++ b/Muramasa The Demon Blade/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Muramasa The Demon Blade/UniversalDIT_Simple-Default.json
+++ b/Muramasa The Demon Blade/UniversalDIT_Simple-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Need for Speed Carbon_GC/UniversalDIT_Simple-Default.json
+++ b/Need for Speed Carbon_GC/UniversalDIT_Simple-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Need for Speed Carbon_GC/UniversalDIT_Simple-Default_EX.json
+++ b/Need for Speed Carbon_GC/UniversalDIT_Simple-Default_EX.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Need for Speed Carbon_Wii/UniversalDIT_Simple-Default.json
+++ b/Need for Speed Carbon_Wii/UniversalDIT_Simple-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Need for Speed Most Wanted/UniversalDIT_Flat_Pressed.json
+++ b/Need for Speed Most Wanted/UniversalDIT_Flat_Pressed.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Need for Speed Most Wanted/UniversalDIT_Simple-Default.json
+++ b/Need for Speed Most Wanted/UniversalDIT_Simple-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Need for Speed Most Wanted/UniversalDIT_Simple-Default_Ex.json
+++ b/Need for Speed Most Wanted/UniversalDIT_Simple-Default_Ex.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Simple-Default/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Simple-Default/Cross.png",

--- a/Need for Speed Undercover/UniversalDIT_Flat.json
+++ b/Need for Speed Undercover/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Need for Speed Undercover/UniversalDIT_Flat_Pressed.json
+++ b/Need for Speed Undercover/UniversalDIT_Flat_Pressed.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Need for Speed Undercover/UniversalDIT_Simple-Default.json
+++ b/Need for Speed Undercover/UniversalDIT_Simple-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Need for Speed Undercover/UniversalDIT_Simple-Speed.json
+++ b/Need for Speed Undercover/UniversalDIT_Simple-Speed.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "Simple-Speed/XBOX ONE/Left Y-.png",
       "`Axis 0+`": "Simple-Speed/XBOX ONE/Left X+.png",
       "`Axis 0-`": "Simple-Speed/XBOX ONE/Left X-.png",
-      "THUMBR": "Simple-Speed/XBOX ONE/Thumb L.png",
+      "THUMBR": "Simple-Speed/XBOX ONE/Thumb R.png",
       "`Axis 4-`": "Simple-Speed/XBOX ONE/Right Y+.png",
       "`Axis 4+`": "Simple-Speed/XBOX ONE/Right Y-.png",
       "`Axis 3+`": "Simple-Speed/XBOX ONE/Right X+.png",
       "`Axis 3-`": "Simple-Speed/XBOX ONE/Right X-.png",
-      "THUMBL": "Simple-Speed/XBOX ONE/Thumb R.png"
+      "THUMBL": "Simple-Speed/XBOX ONE/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "Simple-Speed/XBOX ONE/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "Simple-Speed/XBOX ONE/Left Y-.png",
       "`Axis 0+`": "Simple-Speed/XBOX ONE/Left X+.png",
       "`Axis 0-`": "Simple-Speed/XBOX ONE/Left X-.png",
-      "THUMBR": "Simple-Speed/XBOX ONE/Thumb L.png",
+      "THUMBR": "Simple-Speed/XBOX ONE/Thumb R.png",
       "`Axis 4-`": "Simple-Speed/XBOX ONE/Right Y+.png",
       "`Axis 4+`": "Simple-Speed/XBOX ONE/Right Y-.png",
       "`Axis 3+`": "Simple-Speed/XBOX ONE/Right X+.png",
       "`Axis 3-`": "Simple-Speed/XBOX ONE/Right X-.png",
-      "THUMBL": "Simple-Speed/XBOX ONE/Thumb R.png"
+      "THUMBL": "Simple-Speed/XBOX ONE/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "Simple-Speed/DualShock4/Icon.png",

--- a/Need for Speed Underground 2/UniversalDIT_Flat.json
+++ b/Need for Speed Underground 2/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Need for Speed Underground 2/UniversalDIT_Simple-Speed.json
+++ b/Need for Speed Underground 2/UniversalDIT_Simple-Speed.json
@@ -469,12 +469,12 @@
       "`Axis 1+`": "Simple-Speed/XBOX ONE/Left Y-.png",
       "`Axis 0+`": "Simple-Speed/XBOX ONE/Left X+.png",
       "`Axis 0-`": "Simple-Speed/XBOX ONE/Left X-.png",
-      "THUMBR": "Simple-Speed/XBOX ONE/Thumb L.png",
+      "THUMBR": "Simple-Speed/XBOX ONE/Thumb R.png",
       "`Axis 4-`": "Simple-Speed/XBOX ONE/Right Y+.png",
       "`Axis 4+`": "Simple-Speed/XBOX ONE/Right Y-.png",
       "`Axis 3+`": "Simple-Speed/XBOX ONE/Right X+.png",
       "`Axis 3-`": "Simple-Speed/XBOX ONE/Right X-.png",
-      "THUMBL": "Simple-Speed/XBOX ONE/Thumb R.png"
+      "THUMBL": "Simple-Speed/XBOX ONE/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "Simple-Speed/XBOX ONE/Button A.png",
@@ -496,12 +496,12 @@
       "`Axis 1+`": "Simple-Speed/XBOX ONE/Left Y-.png",
       "`Axis 0+`": "Simple-Speed/XBOX ONE/Left X+.png",
       "`Axis 0-`": "Simple-Speed/XBOX ONE/Left X-.png",
-      "THUMBR": "Simple-Speed/XBOX ONE/Thumb L.png",
+      "THUMBR": "Simple-Speed/XBOX ONE/Thumb R.png",
       "`Axis 4-`": "Simple-Speed/XBOX ONE/Right Y+.png",
       "`Axis 4+`": "Simple-Speed/XBOX ONE/Right Y-.png",
       "`Axis 3+`": "Simple-Speed/XBOX ONE/Right X+.png",
       "`Axis 3-`": "Simple-Speed/XBOX ONE/Right X-.png",
-      "THUMBL": "Simple-Speed/XBOX ONE/Thumb R.png"
+      "THUMBL": "Simple-Speed/XBOX ONE/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "Simple-Speed/DualShock4/Cross.png",

--- a/Need for Speed Underground 2/UniversalDIT_Simple-Speed_EX.json
+++ b/Need for Speed Underground 2/UniversalDIT_Simple-Speed_EX.json
@@ -469,12 +469,12 @@
       "`Axis 1+`": "Simple-Speed/XBOX ONE/Left Stick.png",
       "`Axis 0+`": "Simple-Speed/XBOX ONE/Left Stick.png",
       "`Axis 0-`": "Simple-Speed/XBOX ONE/Left Stick.png",
-      "THUMBR": "Simple-Speed/XBOX ONE/Thumb L.png",
+      "THUMBR": "Simple-Speed/XBOX ONE/Thumb R.png",
       "`Axis 4-`": "Simple-Speed/XBOX ONE/Right Stick.png",
       "`Axis 4+`": "Simple-Speed/XBOX ONE/Right Stick.png",
       "`Axis 3+`": "Simple-Speed/XBOX ONE/Right Stick.png",
       "`Axis 3-`": "Simple-Speed/XBOX ONE/Right Stick.png",
-      "THUMBL": "Simple-Speed/XBOX ONE/Thumb R.png"
+      "THUMBL": "Simple-Speed/XBOX ONE/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "Simple-Speed/XBOX ONE/Button A.png",
@@ -496,12 +496,12 @@
       "`Axis 1+`": "Simple-Speed/XBOX ONE/Left Stick.png",
       "`Axis 0+`": "Simple-Speed/XBOX ONE/Left Stick.png",
       "`Axis 0-`": "Simple-Speed/XBOX ONE/Left Stick.png",
-      "THUMBR": "Simple-Speed/XBOX ONE/Thumb L.png",
+      "THUMBR": "Simple-Speed/XBOX ONE/Thumb R.png",
       "`Axis 4-`": "Simple-Speed/XBOX ONE/Right Stick.png",
       "`Axis 4+`": "Simple-Speed/XBOX ONE/Right Stick.png",
       "`Axis 3+`": "Simple-Speed/XBOX ONE/Right Stick.png",
       "`Axis 3-`": "Simple-Speed/XBOX ONE/Right Stick.png",
-      "THUMBL": "Simple-Speed/XBOX ONE/Thumb R.png"
+      "THUMBL": "Simple-Speed/XBOX ONE/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "Simple-Speed/DualShock4/Cross.png",

--- a/Need for Speed Underground/UniversalDIT_Flat_Pressed.json
+++ b/Need for Speed Underground/UniversalDIT_Flat_Pressed.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Need for Speed Underground/UniversalDIT_Simple-Default.json
+++ b/Need for Speed Underground/UniversalDIT_Simple-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Need for Speed Underground/UniversalDIT_Simple-Default_EX.json
+++ b/Need for Speed Underground/UniversalDIT_Simple-Default_EX.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Simple-Default/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Simple-Default/Cross.png",

--- a/New Super Mario Wii/UniversalDIT_Flat.json
+++ b/New Super Mario Wii/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Newer Super Mario Wii/UniversalDIT_Flat.json
+++ b/Newer Super Mario Wii/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/One Piece Grand Adventure/UniversalDIT_Flat.json
+++ b/One Piece Grand Adventure/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Pandora's Tower/UniversalDIT_Defaultstyle.json
+++ b/Pandora's Tower/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Pandora's Tower/UniversalDIT_Flat.json
+++ b/Pandora's Tower/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Pandora's Tower/UniversalDIT_Flat_Pressed.json
+++ b/Pandora's Tower/UniversalDIT_Flat_Pressed.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Flat_Pressed/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Flat_Pressed/Cross.png",

--- a/Paper Mario The Thousand-Year Door/UniversalDIT_Defaultstyle.json
+++ b/Paper Mario The Thousand-Year Door/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Paper Mario The Thousand-Year Door/UniversalDIT_Defaultstyle_Pressed.json
+++ b/Paper Mario The Thousand-Year Door/UniversalDIT_Defaultstyle_Pressed.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Defaultstyle_Pressed/Cross.png",

--- a/Paper Mario The Thousand-Year Door/UniversalDIT_Flat.json
+++ b/Paper Mario The Thousand-Year Door/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Paper Mario/UniversalDIT_Defaultstyle.json
+++ b/Paper Mario/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Paper Mario/UniversalDIT_Flat.json
+++ b/Paper Mario/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Phantasy Star Online 1&2/UniversalDIT_Flat.json
+++ b/Phantasy Star Online 1&2/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Pikmin1_GC/UniversalDIT_Defaultstyle.json
+++ b/Pikmin1_GC/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Pikmin1_GC/UniversalDIT_Flat.json
+++ b/Pikmin1_GC/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Pikmin1_Wii/UniversalDIT_Defaultstyle.json
+++ b/Pikmin1_Wii/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Pikmin1_Wii/UniversalDIT_Flat.json
+++ b/Pikmin1_Wii/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Pikmin2_GC/UniversalDIT_Flat.json
+++ b/Pikmin2_GC/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Pikmin2_Wii/UniversalDIT_Defaultstyle.json
+++ b/Pikmin2_Wii/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Pokemon Box/UniversalDIT_Flat.json
+++ b/Pokemon Box/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Pokemon Colosseum/UniversalDIT_Defaultstyle.json
+++ b/Pokemon Colosseum/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Pokemon Colosseum/UniversalDIT_Flat.json
+++ b/Pokemon Colosseum/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Pokemon Snap/UniversalDIT_Flat.json
+++ b/Pokemon Snap/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Pokemon Snap/UniversalDIT_Flat_Pressed.json
+++ b/Pokemon Snap/UniversalDIT_Flat_Pressed.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Flat_Pressed/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Flat_Pressed/Cross.png",

--- a/Pokemon XD/UniversalDIT_Flat.json
+++ b/Pokemon XD/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Prince of Persia The Sands of Time/UniversalDIT_Flat_Mirror.json
+++ b/Prince of Persia The Sands of Time/UniversalDIT_Flat_Mirror.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Flat/Cross.png",

--- a/Prince of Persia The Two Thrones/UniversalDIT_Flat_Mask_Mirror.json
+++ b/Prince of Persia The Two Thrones/UniversalDIT_Flat_Mask_Mirror.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Mask/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Mask/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Mask/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Mask/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Mask/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Mask/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Mask/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Mask/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Mask/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Mask/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Mask/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Mask/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Mask/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Mask/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Mask/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Mask/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Mask/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Mask/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Mask/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Mask/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Mask/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Mask/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Mask/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Flat_Mask/Cross.png",

--- a/Prince of Persia The Two Thrones/UniversalDIT_Flat_Mirror.json
+++ b/Prince of Persia The Two Thrones/UniversalDIT_Flat_Mirror.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Flat/Cross.png",

--- a/Prince of Persia Warrior Within/UniversalDIT_Flat_Mask_Mirror.json
+++ b/Prince of Persia Warrior Within/UniversalDIT_Flat_Mask_Mirror.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Mask/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Mask/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Mask/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Mask/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Mask/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Mask/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Mask/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Mask/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Mask/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Mask/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat_Mask/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Mask/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Mask/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Mask/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Mask/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Mask/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Mask/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Mask/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Mask/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Mask/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Mask/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Mask/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat_Mask/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Flat_Mask/Cross.png",

--- a/Prince of Persia Warrior Within/UniversalDIT_Flat_Mirror.json
+++ b/Prince of Persia Warrior Within/UniversalDIT_Flat_Mirror.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Flat/Cross.png",

--- a/Punch Out/UniversalDIT_Flat.json
+++ b/Punch Out/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Rayman 3/UniversalDIT_Flat.json
+++ b/Rayman 3/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Rayman Raving Rabbids 2/UniversalDIT_Flat_Mirror.json
+++ b/Rayman Raving Rabbids 2/UniversalDIT_Flat_Mirror.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Flat/Cross.png",

--- a/Rayman Raving Rabbids/UniversalDIT_Flat_Mirror.json
+++ b/Rayman Raving Rabbids/UniversalDIT_Flat_Mirror.json
@@ -497,12 +497,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Button A.png",
@@ -524,12 +524,12 @@
       "`Axis 1+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/_Mirror/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/_Mirror/DualShock4/Flat/Cross.png",

--- a/Resident Evil 4/UniversalDIT_Flat.json
+++ b/Resident Evil 4/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Rune Factory Frontier/UniversalDIT_Flat.json
+++ b/Rune Factory Frontier/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Rune Factory Tides of Destiny/UniversalDIT_Defaultstyle.json
+++ b/Rune Factory Tides of Destiny/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Rune Factory Tides of Destiny/UniversalDIT_Flat.json
+++ b/Rune Factory Tides of Destiny/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Rune Factory Tides of Destiny/UniversalDIT_Flat_Pressed.json
+++ b/Rune Factory Tides of Destiny/UniversalDIT_Flat_Pressed.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Flat_Pressed/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Flat_Pressed/Cross.png",

--- a/Samurai Warriors Katana/UniversalDIT_Defaultstyle.json
+++ b/Samurai Warriors Katana/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Samurai Warriors Katana/UniversalDIT_Defaultstyle_Pressed.json
+++ b/Samurai Warriors Katana/UniversalDIT_Defaultstyle_Pressed.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Defaultstyle_Pressed/Cross.png",

--- a/Samurai Warriors Katana/UniversalDIT_Flat.json
+++ b/Samurai Warriors Katana/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Shadow the Hedgehog/UniversalDIT_Flat.json
+++ b/Shadow the Hedgehog/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Shrek SuperSlam/UniversalDIT_Flat.json
+++ b/Shrek SuperSlam/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Sin and Punishment 2/UniversalDIT_Flat.json
+++ b/Sin and Punishment 2/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Sin and Punishment/UniversalDIT_Flat.json
+++ b/Sin and Punishment/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Sin and Punishment/UniversalDIT_Flat_Pressed.json
+++ b/Sin and Punishment/UniversalDIT_Flat_Pressed.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Flat_Pressed/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Flat_Pressed/Cross.png",

--- a/Sonic Colours/UniversalDIT_Flat.json
+++ b/Sonic Colours/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Sonic Colours/UniversalDIT_Simple-Default.json
+++ b/Sonic Colours/UniversalDIT_Simple-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Sonic Mega Collection/UniversalDIT_Flat.json
+++ b/Sonic Mega Collection/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Sonic Riders/UniversalDIT_Flat.json
+++ b/Sonic Riders/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Sonic and the Black Knight/UniversalDIT_Flat.json
+++ b/Sonic and the Black Knight/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Soulcalibur II/UniversalDIT_Flat.json
+++ b/Soulcalibur II/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Spider-Man Shattered Dimensions/UniversalDIT_Flat.json
+++ b/Spider-Man Shattered Dimensions/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Star Fox Adventures/UniversalDIT_Flat.json
+++ b/Star Fox Adventures/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Star Fox Assault/UniversalDIT_Flat.json
+++ b/Star Fox Assault/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Star Fox Assault/UniversalDIT_Text-Outlines.json
+++ b/Star Fox Assault/UniversalDIT_Text-Outlines.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Super Mario 64/UniversalDIT_Text 64.json
+++ b/Super Mario 64/UniversalDIT_Text 64.json
@@ -471,12 +471,12 @@
       "`Axis 1+`": "Text 64/XBOX ONE/Left Y-.png",
       "`Axis 0+`": "Text 64/XBOX ONE/Left X+.png",
       "`Axis 0-`": "Text 64/XBOX ONE/Left X-.png",
-      "THUMBR": "Text 64/XBOX ONE/Thumb L.png",
+      "THUMBR": "Text 64/XBOX ONE/Thumb R.png",
       "`Axis 4-`": "Text 64/XBOX ONE/Right Y+.png",
       "`Axis 4+`": "Text 64/XBOX ONE/Right Y-.png",
       "`Axis 3+`": "Text 64/XBOX ONE/Right X+.png",
       "`Axis 3-`": "Text 64/XBOX ONE/Right X-.png",
-      "THUMBL": "Text 64/XBOX ONE/Thumb R.png"
+      "THUMBL": "Text 64/XBOX ONE/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "Text 64/XBOX ONE/Button A.png",
@@ -498,12 +498,12 @@
       "`Axis 1+`": "Text 64/XBOX ONE/Left Y-.png",
       "`Axis 0+`": "Text 64/XBOX ONE/Left X+.png",
       "`Axis 0-`": "Text 64/XBOX ONE/Left X-.png",
-      "THUMBR": "Text 64/XBOX ONE/Thumb L.png",
+      "THUMBR": "Text 64/XBOX ONE/Thumb R.png",
       "`Axis 4-`": "Text 64/XBOX ONE/Right Y+.png",
       "`Axis 4+`": "Text 64/XBOX ONE/Right Y-.png",
       "`Axis 3+`": "Text 64/XBOX ONE/Right X+.png",
       "`Axis 3-`": "Text 64/XBOX ONE/Right X-.png",
-      "THUMBL": "Text 64/XBOX ONE/Thumb R.png"
+      "THUMBL": "Text 64/XBOX ONE/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "Text 64/DualShock4/Cross.png",

--- a/Super Mario Galaxy 2/UniversalDIT_Flat.json
+++ b/Super Mario Galaxy 2/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Super Mario Galaxy 2/UniversalDIT_Flat_Pressed.json
+++ b/Super Mario Galaxy 2/UniversalDIT_Flat_Pressed.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Flat_Pressed/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Flat_Pressed/Cross.png",

--- a/Super Mario Galaxy/UniversalDIT_Flat.json
+++ b/Super Mario Galaxy/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Super Mario Galaxy/UniversalDIT_Flat_Pressed.json
+++ b/Super Mario Galaxy/UniversalDIT_Flat_Pressed.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Flat_Pressed/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Flat_Pressed/Cross.png",

--- a/Super Mario Strikers/UniversalDIT_Flat.json
+++ b/Super Mario Strikers/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Super Mario Sunshine/UniversalDIT_Simple-Default.json
+++ b/Super Mario Sunshine/UniversalDIT_Simple-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Super Mario Sunshine/UniversalDIT_Text-Default.json
+++ b/Super Mario Sunshine/UniversalDIT_Text-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Text-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Text-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Text-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Text-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Text-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Text-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Text-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Text-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Text-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Text-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Text-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Text-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Text-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Text-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Super Mario Sunshine/UniversalDIT_Text-Outlines.json
+++ b/Super Mario Sunshine/UniversalDIT_Text-Outlines.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Super Monkey Ball 2/UniversalDIT_Flat.json
+++ b/Super Monkey Ball 2/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Super Monkey Ball/UniversalDIT_Flat.json
+++ b/Super Monkey Ball/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Super Paper Mario/UniversalDIT_Defaultstyle.json
+++ b/Super Paper Mario/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Super Paper Mario/UniversalDIT_Defaultstyle_Pressed.json
+++ b/Super Paper Mario/UniversalDIT_Defaultstyle_Pressed.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Defaultstyle_Pressed/Cross.png",

--- a/Super Paper Mario/UniversalDIT_Flat.json
+++ b/Super Paper Mario/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Super Paper Mario/UniversalDIT_Flat_Pressed.json
+++ b/Super Paper Mario/UniversalDIT_Flat_Pressed.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Flat_Pressed/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Flat_Pressed/Cross.png",

--- a/Super Smash Bros Brawl/UniversalDIT_Flat.json
+++ b/Super Smash Bros Brawl/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Super Smash Bros Melee/UniversalDIT_Flat.json
+++ b/Super Smash Bros Melee/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Super Smash Bros/UniversalDIT_Flat.json
+++ b/Super Smash Bros/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Tales of Symphonia/UniversalDIT_Defaultstyle.json
+++ b/Tales of Symphonia/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Tales of Symphonia/UniversalDIT_Defaultstyle_Pressed.json
+++ b/Tales of Symphonia/UniversalDIT_Defaultstyle_Pressed.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Defaultstyle_Pressed/Cross.png",

--- a/The Bigs 2/UniversalDIT_Flat.json
+++ b/The Bigs 2/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/The Last Story/UniversalDIT_Flat.json
+++ b/The Last Story/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/The Last Story/UniversalDIT_Simple-Default.json
+++ b/The Last Story/UniversalDIT_Simple-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/The Last Story/UniversalDIT_Text-Outlines.json
+++ b/The Last Story/UniversalDIT_Text-Outlines.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/The Simpsons/UniversalDIT_Flat.json
+++ b/The Simpsons/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/The Sims/UniversalDIT_Flat.json
+++ b/The Sims/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Tony Hawk's Proving Ground/UniversalDIT_Flat.json
+++ b/Tony Hawk's Proving Ground/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Viewtiful Joe/UniversalDIT_Flat.json
+++ b/Viewtiful Joe/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/WarioWare Inc/UniversalDIT_Flat.json
+++ b/WarioWare Inc/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Wii Menu/UniversalDIT_Flat.json
+++ b/Wii Menu/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Wii Menu/UniversalDIT_Simple-Default.json
+++ b/Wii Menu/UniversalDIT_Simple-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Wii Menu/UniversalDIT_Text-Default.json
+++ b/Wii Menu/UniversalDIT_Text-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Text-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Text-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Text-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Text-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Text-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Text-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Text-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Text-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Text-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Text-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Text-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Text-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Text-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Text-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Wii Sports Resort/UniversalDIT_Flat.json
+++ b/Wii Sports Resort/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Wii Sports Resort/UniversalDIT_Simple-Default.json
+++ b/Wii Sports Resort/UniversalDIT_Simple-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Wii Sports/UniversalDIT_Defaultstyle.json
+++ b/Wii Sports/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Wii Sports/UniversalDIT_Flat.json
+++ b/Wii Sports/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Wii Sports/UniversalDIT_Simple-Default.json
+++ b/Wii Sports/UniversalDIT_Simple-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Xenoblade Chronicles/UniversalDIT_Defaultstyle.json
+++ b/Xenoblade Chronicles/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Xenoblade Chronicles/UniversalDIT_Flat.json
+++ b/Xenoblade Chronicles/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Xenoblade Chronicles/UniversalDIT_Flat_Pressed.json
+++ b/Xenoblade Chronicles/UniversalDIT_Flat_Pressed.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Flat_Pressed/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Flat_Pressed/Cross.png",

--- a/Zelda 64/UniversalDIT_Flat.json
+++ b/Zelda 64/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Zelda 64/UniversalDIT_Simple-Default.json
+++ b/Zelda 64/UniversalDIT_Simple-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Simple-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Simple-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Simple-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Simple-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Zelda 64/UniversalDIT_Text-Default.json
+++ b/Zelda 64/UniversalDIT_Text-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Text-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Text-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Text-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Text-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Text-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Text-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Text-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Text-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Text-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Text-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Text-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Text-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Text-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Text-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Zelda 64/UniversalDIT_Text-Outlines.json
+++ b/Zelda 64/UniversalDIT_Text-Outlines.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Zelda Four Swords/UniversalDIT_Text-Outlines.json
+++ b/Zelda Four Swords/UniversalDIT_Text-Outlines.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Zelda Skyward Sword/UniversalDIT_Defaultstyle.json
+++ b/Zelda Skyward Sword/UniversalDIT_Defaultstyle.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Zelda Skyward Sword/UniversalDIT_Defaultstyle_Pressed.json
+++ b/Zelda Skyward Sword/UniversalDIT_Defaultstyle_Pressed.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Defaultstyle_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Defaultstyle_Pressed/Cross.png",

--- a/Zelda Skyward Sword/UniversalDIT_Flat.json
+++ b/Zelda Skyward Sword/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Zelda Twilight Princess_GC/UniversalDIT_Flat.json
+++ b/Zelda Twilight Princess_GC/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Zelda Twilight Princess_GC/UniversalDIT_Flat_Pressed.json
+++ b/Zelda Twilight Princess_GC/UniversalDIT_Flat_Pressed.json
@@ -498,12 +498,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "SOUTH": "../#DefaultDevices/XBOX 360/Flat_Pressed/Button A.png",
@@ -525,12 +525,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Left Stick.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat_Pressed/Right Stick.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat_Pressed/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "SOUTH": "../#DefaultDevices/DualShock4/Flat_Pressed/Cross.png",

--- a/Zelda Twilight Princess_GC/UniversalDIT_Text-Default.json
+++ b/Zelda Twilight Princess_GC/UniversalDIT_Text-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Text-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Text-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Text-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Text-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Text-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Text-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Text-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Text-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Text-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Text-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Text-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Text-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Text-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Text-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Zelda Twilight Princess_GC/UniversalDIT_Text-Outlines.json
+++ b/Zelda Twilight Princess_GC/UniversalDIT_Text-Outlines.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Zelda Twilight Princess_Wii/UniversalDIT_Flat.json
+++ b/Zelda Twilight Princess_Wii/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Zelda Twilight Princess_Wii/UniversalDIT_Text-Default.json
+++ b/Zelda Twilight Princess_Wii/UniversalDIT_Text-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Text-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Text-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Text-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Text-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Text-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Text-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Text-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Text-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Text-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Text-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Text-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Text-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Text-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Text-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Zelda Wind Waker/UniversalDIT_Flat.json
+++ b/Zelda Wind Waker/UniversalDIT_Flat.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Flat/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Flat/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Flat/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Flat/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Flat/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Flat/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Flat/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Flat/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Flat/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Zelda Wind Waker/UniversalDIT_Text-Default.json
+++ b/Zelda Wind Waker/UniversalDIT_Text-Default.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Text-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Text-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Text-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Text-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Text-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Text-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Text-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Default/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Text-Default/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Text-Default/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Text-Default/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Default/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Default/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Text-Default/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Text-Default/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Text-Default/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Text-Default/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Default/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Default/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",

--- a/Zelda Wind Waker/UniversalDIT_Text-Outlines.json
+++ b/Zelda Wind Waker/UniversalDIT_Text-Outlines.json
@@ -506,12 +506,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX ONE/Text-Outlines/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX ONE/Text-Outlines/Thumb L.png"
     },
     "evdev/0/Microsoft X-Box 360 pad": {
       "evdev/0/Microsoft X-Box 360 pad": "../#DefaultDevices/XBOX ONE/Device/Icon.png",
@@ -534,12 +534,12 @@
       "`Axis 1+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left Y-.png",
       "`Axis 0+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left X+.png",
       "`Axis 0-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Left X-.png",
-      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb L.png",
+      "THUMBR": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb R.png",
       "`Axis 4-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right Y+.png",
       "`Axis 4+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right Y-.png",
       "`Axis 3+`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right X+.png",
       "`Axis 3-`": "../#DefaultDevices/XBOX 360/Text-Outlines/Right X-.png",
-      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb R.png"
+      "THUMBL": "../#DefaultDevices/XBOX 360/Text-Outlines/Thumb L.png"
     },
     "evdev/0/Wireless Controller": {
       "evdev/0/Wireless Controller": "../#DefaultDevices/DualShock4/Device/Icon.png",


### PR DESCRIPTION
Thumb L and Thumb R were swapped for "evdev/0/Microsoft X-Box One S pad" and "evdev/0/Microsoft X-Box 360 pad"