### PR TITLE
Punch Out Button 1 Fix

### DIFF
--- a/Punch Out/UniversalDIT_Flat.json
+++ b/Punch Out/UniversalDIT_Flat.json
@@ -1075,7 +1075,7 @@
       "image": "tex1_128x128.png",
       "emulated_controls": {
         "Wiimote1": {
-          "Buttons/A": [
+          "Buttons/1": [
             [
               0.0,
               0.0,


### PR DESCRIPTION
Reassigned a texture mapping from the Wiimote's A button to the 1 button